### PR TITLE
Update to urllib3 1.26.13

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     author="BhavKaran (bhavsec.com)",
     author_email="bhavsec@gmail.com",
     license="GPL-3.0",
-    install_requires=["shodan", "requests", "prompt_toolkit","wget","beautifulsoup4","click","urllib3","IP2proxy","wget","paramiko","h8mail","nmap","pythonping","whois","gmplot","pillow","lxml","tweepy"],
+    install_requires=["shodan", "requests", "prompt_toolkit","wget","beautifulsoup4","click","urllib3=1.26.13","IP2proxy","wget","paramiko","h8mail","nmap","pythonping","whois","gmplot","pillow","lxml","tweepy"],
     console=["reconspider.py"],
 )
 


### PR DESCRIPTION
Module version is required urllib3 1.26.13 but it is installing non-dependent module version urllib3 2.0.0a2
```
error: urllib3 2.0.0a2 is installed but urllib3<1.27,>=1.21.1 is required by {'requests'}
```